### PR TITLE
Fix `plugins` part of the response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ def pluginDescription = 'Plugin to list node built-in analyzers'
 def projectPath = 'org.opensearch'
 def pathToPlugin = 'plugin.node.analyzers'
 def pluginClassName = 'NodeAnalyzersPlugin'
-group = "RenameGroup"
+group = "org.opensearch"
 
 publishing {
     publications {
@@ -100,10 +100,12 @@ testClusters.integTest {
     plugin(project.tasks.bundlePlugin.archiveFile)
 }
 
-// We should be able to do this later if the code is part of the core.
-//testClusters.all {
-//    module ':plugins:analysis-icu'
-//}
+// Include testing plugins into the cluster. These are AnalysisPlugin(s) and they provide analysis components.
+testClusters.all {
+    numberOfNodes = 2
+    module ':testPlugin_01'
+    module ':testPlugin_02'
+}
 
 run {
     useCluster testClusters.integTest
@@ -118,5 +120,10 @@ task updateVersion {
          // String tokenization to support -SNAPSHOT
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
+}
+
+dependencies {
+    testRuntimeOnly project(':testPlugin_01')
+    testRuntimeOnly project(':testPlugin_02')
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,5 @@
  */
 
 rootProject.name = 'ListBuiltInAnalyzers'
+include 'testPlugin_01'
+include 'testPlugin_02'

--- a/src/main/java/org/opensearch/plugin/action/NodesAnalyzersResponse.java
+++ b/src/main/java/org/opensearch/plugin/action/NodesAnalyzersResponse.java
@@ -58,10 +58,10 @@ public class NodesAnalyzersResponse extends BaseNodesResponse<NodeAnalyzersInfo>
             builder.field("charFilters").value(nodeInfo.getCharFiltersKeySet());
             builder.field("normalizers").value(nodeInfo.getNormalizersKeySet());
 
-            builder.startObject("plugins");
+            builder.startArray("plugins");
             for (String plugin : nodeInfo.getNodeAnalysisPlugins().keySet()) {
                 NodeAnalyzersInfo.AnalysisPluginComponents pluginComponents = nodeInfo.getNodeAnalysisPlugins().get(plugin);
-                builder.startObject("plugin");
+                builder.startObject();
                 builder.field("name", pluginComponents.getPluginName());
                 builder.field("analyzers").value(pluginComponents.getAnalyzersKeySet());
                 builder.field("tokenizers").value(pluginComponents.getTokenizersKeySet());
@@ -70,7 +70,7 @@ public class NodesAnalyzersResponse extends BaseNodesResponse<NodeAnalyzersInfo>
                 builder.field("hunspellDictionaries").value(pluginComponents.getHunspellDictionaries());
                 builder.endObject();
             }
-            builder.endObject();
+            builder.endArray();
 
             builder.endObject();
         }

--- a/src/yamlRestTest/resources/rest-api-spec/test/10_cat_API_check.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/10_cat_API_check.yml
@@ -5,4 +5,4 @@
         h: component
 
   - match:
-      $body: /^node\-analyzers\n$/
+      $body: /^node\-analyzers\nnode\-analyzers\n$/

--- a/src/yamlRestTest/resources/rest-api-spec/test/20_simple.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/20_simple.yml
@@ -6,7 +6,7 @@ setup:
   - do:
       nodes.analyzers: {}
 
-  - length: { nodes: 1 }
+  - length: { nodes: 2 }
 
   - set:
       nodes._arbitrary_key_: node_id
@@ -19,10 +19,11 @@ setup:
   - is_true: nodes.$node_id.plugins
 
   - length: { nodes.$node_id.analyzers: 6 }
-  - length: { nodes.$node_id.tokenizers: 1 }
-  - length: { nodes.$node_id.tokenFilters: 4 }
+  - length: { nodes.$node_id.tokenizers: 3 }
+  - length: { nodes.$node_id.tokenFilters: 6 }
   - length: { nodes.$node_id.charFilters: 0 }
   - length: { nodes.$node_id.normalizers: 1 }
+  - length: { nodes.$node_id.plugins: 2 }
 
   # Items are sorted.
   - match: { nodes.$node_id.analyzers.0: "default" }
@@ -33,10 +34,36 @@ setup:
   - match: { nodes.$node_id.analyzers.5: "whitespace" }
 
   - match: { nodes.$node_id.tokenizers.0: "standard" }
+  - match: { nodes.$node_id.tokenizers.1: "xx_test_01_tokenizer" }
+  - match: { nodes.$node_id.tokenizers.2: "xx_test_02_tokenizer" }
 
   - match: { nodes.$node_id.tokenFilters.0: "hunspell" }
   - match: { nodes.$node_id.tokenFilters.1: "shingle" }
   - match: { nodes.$node_id.tokenFilters.2: "standard" }
   - match: { nodes.$node_id.tokenFilters.3: "stop" }
+  - match: { nodes.$node_id.tokenFilters.4: "xx_test_01_tokenFilter" }
+  - match: { nodes.$node_id.tokenFilters.5: "xx_test_02_tokenFilter" }
 
   - match: { nodes.$node_id.normalizers.0: "lowercase" }
+
+  # Verify plugins
+  # First plugin
+  - is_true: nodes.$node_id.plugins.0.name
+  - is_true: nodes.$node_id.plugins.0.analyzers
+  - is_true: nodes.$node_id.plugins.0.tokenizers
+  - is_true: nodes.$node_id.plugins.0.tokenFilters
+  - is_true: nodes.$node_id.plugins.0.charFilters
+  - is_true: nodes.$node_id.plugins.0.hunspellDictionaries
+
+  - match: { nodes.$node_id.plugins.0.name: "org.opensearch.plugin.Test01AnalysisPlugin" }
+  - length: { nodes.$node_id.plugins.0.analyzers: 0 }
+  - length: { nodes.$node_id.plugins.0.tokenizers: 1 }
+  - length: { nodes.$node_id.plugins.0.tokenFilters: 1 }
+  - length: { nodes.$node_id.plugins.0.charFilters: 0 }
+  - length: { nodes.$node_id.plugins.0.hunspellDictionaries: 0 }
+
+  - match: { nodes.$node_id.plugins.0.tokenizers.0: "xx_test_01_tokenizer" }
+  - match: { nodes.$node_id.plugins.0.tokenFilters.0: "xx_test_01_tokenFilter" }
+
+  # Second plugin
+  - match: { nodes.$node_id.plugins.1.name: "org.opensearch.plugin.Test02AnalysisPlugin" }

--- a/testPlugin_01/build.gradle
+++ b/testPlugin_01/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'opensearch.opensearchplugin'
+
+opensearchplugin {
+    name 'test1-analyzer'
+    description 'Testing AnalysisPlugin #1'
+    classname 'org.opensearch.plugin.Test01AnalysisPlugin'
+    licenseFile rootProject.file('LICENSE.txt')
+    noticeFile rootProject.file('NOTICE.txt')
+}
+
+// thirdparty audit needs can be enabled
+thirdPartyAudit.enabled = false
+
+// This requires an additional Jar not published as part of build-tools
+loggerUsageCheck.enabled = false
+
+// No need to validate pom, as we do not upload to maven/sonatype
+validateNebulaPom.enabled = false
+
+// No unit tests in this plugin
+test.enabled = false
+
+buildscript {
+    ext {
+//        opensearch.version = "2.4.1"
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+    }
+
+    repositories {
+        mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+
+    dependencies {
+        classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
+    }
+}
+
+repositories {
+    mavenLocal()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+    mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
+}

--- a/testPlugin_01/src/main/java/org/opensearch/plugin/Test01AnalysisPlugin.java
+++ b/testPlugin_01/src/main/java/org/opensearch/plugin/Test01AnalysisPlugin.java
@@ -1,0 +1,158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.plugin;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.Environment;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.analysis.AbstractTokenFilterFactory;
+import org.opensearch.index.analysis.AbstractTokenizerFactory;
+import org.opensearch.index.analysis.AnalysisMode;
+import org.opensearch.index.analysis.CharFilterFactory;
+import org.opensearch.index.analysis.TokenFilterFactory;
+import org.opensearch.index.analysis.TokenizerFactory;
+import org.opensearch.indices.analysis.AnalysisModule;
+import org.opensearch.plugins.AnalysisPlugin;
+import org.opensearch.plugins.Plugin;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * AnalysisPlugin that is included and deployed into testing cluster.
+ */
+public class Test01AnalysisPlugin extends Plugin implements AnalysisPlugin {
+
+//    @Override
+//    public Map<String, AnalysisModule.AnalysisProvider<AnalyzerProvider<? extends Analyzer>>> getAnalyzers() {
+//        return Collections.singletonMap("test_analyzer", TestAnalyzerProvider::new);
+//    }
+
+    @Override
+    public Map<String, AnalysisModule.AnalysisProvider<TokenizerFactory>> getTokenizers() {
+        return Collections.singletonMap("xx_test_01_tokenizer", TestTokenizer::new);
+    }
+
+    @Override
+    public Map<String, AnalysisModule.AnalysisProvider<TokenFilterFactory>> getTokenFilters() {
+        return Collections.singletonMap("xx_test_01_tokenFilter", TestTokenFilter::new);
+    }
+
+
+//    private class TestAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analyzer> {
+//        public TestAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
+//            super(indexSettings, name, settings);
+//        }
+//
+//        /**
+//         * @return
+//         */
+//        @Override
+//        public Analyzer get() {
+//            return new Analyzer() {
+//                @Override
+//                protected TokenStreamComponents createComponents(String fieldName) {
+//                    return null;
+//                }
+//            };
+//        }
+//    }
+
+    private class TestTokenizer extends AbstractTokenizerFactory {
+        /**
+         * Ctor.
+         * @param indexSettings
+         * @param env
+         * @param settings
+         * @param name
+         */
+        public TestTokenizer(IndexSettings indexSettings, Environment env, String name, Settings settings) {
+            super(indexSettings, settings, name);
+        }
+
+        /**
+         * @return
+         */
+        @Override
+        public Tokenizer create() {
+            return null;
+        }
+    }
+
+    private class TestTokenFilter extends AbstractTokenFilterFactory {
+
+        /**
+         * Ctor.
+         * @param indexSettings
+         * @param name
+         * @param settings
+         */
+        public TestTokenFilter(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
+            super(indexSettings, name, settings);
+        }
+
+        /**
+         * @param tokenStream
+         * @return
+         */
+        @Override
+        public TokenStream create(TokenStream tokenStream) {
+            return null;
+        }
+
+        /**
+         * @param tokenStream
+         * @return
+         */
+        @Override
+        public TokenStream normalize(TokenStream tokenStream) {
+            return super.normalize(tokenStream);
+        }
+
+        /**
+         * @return
+         */
+        @Override
+        public boolean breaksFastVectorHighlighter() {
+            return super.breaksFastVectorHighlighter();
+        }
+
+        /**
+         * @param tokenizer
+         * @param charFilters
+         * @param previousTokenFilters
+         * @param allFilters
+         * @return
+         */
+        @Override
+        public TokenFilterFactory getChainAwareTokenFilterFactory(TokenizerFactory tokenizer, List<CharFilterFactory> charFilters, List<TokenFilterFactory> previousTokenFilters, Function<String, TokenFilterFactory> allFilters) {
+            return super.getChainAwareTokenFilterFactory(tokenizer, charFilters, previousTokenFilters, allFilters);
+        }
+
+        /**
+         * @return
+         */
+        @Override
+        public TokenFilterFactory getSynonymFilter() {
+            return super.getSynonymFilter();
+        }
+
+        /**
+         * @return
+         */
+        @Override
+        public AnalysisMode getAnalysisMode() {
+            return super.getAnalysisMode();
+        }
+    }
+
+}

--- a/testPlugin_02/build.gradle
+++ b/testPlugin_02/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'opensearch.opensearchplugin'
+
+opensearchplugin {
+    name 'test2-analyzer'
+    description 'Testing AnalysisPlugin #2'
+    classname 'org.opensearch.plugin.Test02AnalysisPlugin'
+    licenseFile rootProject.file('LICENSE.txt')
+    noticeFile rootProject.file('NOTICE.txt')
+}
+
+// thirdparty audit needs can be enabled
+thirdPartyAudit.enabled = false
+
+// This requires an additional Jar not published as part of build-tools
+loggerUsageCheck.enabled = false
+
+// No need to validate pom, as we do not upload to maven/sonatype
+validateNebulaPom.enabled = false
+
+// No unit tests in this plugin
+test.enabled = false
+
+buildscript {
+    ext {
+//        opensearch.version = "2.4.1"
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+    }
+
+    repositories {
+        mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+
+    dependencies {
+        classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
+    }
+}
+
+repositories {
+    mavenLocal()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+    mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
+}

--- a/testPlugin_02/src/main/java/org/opensearch/plugin/Test02AnalysisPlugin.java
+++ b/testPlugin_02/src/main/java/org/opensearch/plugin/Test02AnalysisPlugin.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.plugin;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.Environment;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.analysis.AbstractTokenFilterFactory;
+import org.opensearch.index.analysis.AbstractTokenizerFactory;
+import org.opensearch.index.analysis.AnalysisMode;
+import org.opensearch.index.analysis.CharFilterFactory;
+import org.opensearch.index.analysis.TokenFilterFactory;
+import org.opensearch.index.analysis.TokenizerFactory;
+import org.opensearch.indices.analysis.AnalysisModule;
+import org.opensearch.plugins.AnalysisPlugin;
+import org.opensearch.plugins.Plugin;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * AnalysisPlugin that is included and deployed into testing cluster.
+ */
+public class Test02AnalysisPlugin extends Plugin implements AnalysisPlugin {
+
+    @Override
+    public Map<String, AnalysisModule.AnalysisProvider<TokenizerFactory>> getTokenizers() {
+        return Collections.singletonMap("xx_test_02_tokenizer", TestTokenizer::new);
+    }
+
+    @Override
+    public Map<String, AnalysisModule.AnalysisProvider<TokenFilterFactory>> getTokenFilters() {
+        return Collections.singletonMap("xx_test_02_tokenFilter", TestTokenFilter::new);
+    }
+
+    private class TestTokenizer extends AbstractTokenizerFactory {
+        /**
+         * Ctor.
+         * @param indexSettings
+         * @param env
+         * @param settings
+         * @param name
+         */
+        public TestTokenizer(IndexSettings indexSettings, Environment env, String name, Settings settings) {
+            super(indexSettings, settings, name);
+        }
+
+        /**
+         * @return
+         */
+        @Override
+        public Tokenizer create() {
+            return null;
+        }
+    }
+
+    private class TestTokenFilter extends AbstractTokenFilterFactory {
+
+        /**
+         * Ctor.
+         * @param indexSettings
+         * @param name
+         * @param settings
+         */
+        public TestTokenFilter(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
+            super(indexSettings, name, settings);
+        }
+
+        /**
+         * @param tokenStream
+         * @return
+         */
+        @Override
+        public TokenStream create(TokenStream tokenStream) {
+            return null;
+        }
+
+        /**
+         * @param tokenStream
+         * @return
+         */
+        @Override
+        public TokenStream normalize(TokenStream tokenStream) {
+            return super.normalize(tokenStream);
+        }
+
+        /**
+         * @return
+         */
+        @Override
+        public boolean breaksFastVectorHighlighter() {
+            return super.breaksFastVectorHighlighter();
+        }
+
+        /**
+         * @param tokenizer
+         * @param charFilters
+         * @param previousTokenFilters
+         * @param allFilters
+         * @return
+         */
+        @Override
+        public TokenFilterFactory getChainAwareTokenFilterFactory(TokenizerFactory tokenizer, List<CharFilterFactory> charFilters, List<TokenFilterFactory> previousTokenFilters, Function<String, TokenFilterFactory> allFilters) {
+            return super.getChainAwareTokenFilterFactory(tokenizer, charFilters, previousTokenFilters, allFilters);
+        }
+
+        /**
+         * @return
+         */
+        @Override
+        public TokenFilterFactory getSynonymFilter() {
+            return super.getSynonymFilter();
+        }
+
+        /**
+         * @return
+         */
+        @Override
+        public AnalysisMode getAnalysisMode() {
+            return super.getAnalysisMode();
+        }
+    }
+}


### PR DESCRIPTION
- Add two testing AnalysisPlugin(s) by introducing project submodules
- Fixing the `plugins` part of the response
- Increase the number of nodes of testing cluster to 2

Related to #5

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>